### PR TITLE
Wraps: panic on nil error

### DIFF
--- a/structured.go
+++ b/structured.go
@@ -67,6 +67,9 @@ func (se StructuredErr) Format(s fmt.State, verb rune) {
 // S=structured
 // Accepts as args any valid slog args.  These will generate an slog Record
 func Wraps(err error, msg string, args ...interface{}) StructuredErr {
+	if err == nil {
+		err = New("errors.Wraps: given error is nil")
+	}
 	var pc uintptr
 	var pcs [1]uintptr
 	runtime.Callers(2, pcs[:])

--- a/structured_test.go
+++ b/structured_test.go
@@ -42,3 +42,12 @@ func TestStructured(t *testing.T) {
 		t.Errorf("expected stack trace with file")
 	}
 }
+
+func TestStructuredNil(t *testing.T) {
+	err := Wraps(nil, "testing nil error", "test", 1)
+	got := err.Error()
+	expected := "testing nil error test=1: errors.Wraps: given error is nil"
+	if got != expected {
+		t.Errorf("\nexpected: '%s'\n but got: '%s'", expected, got)
+	}
+}


### PR DESCRIPTION
Currently this function already panics.
This panic should provide a much easier to understand message. In the future we could try to have it return nil as many other functions do. That would require changing the return type to error.