### PR TITLE
Structured slogable

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -359,7 +359,7 @@ func writeString(w io.Writer, s string) {
 //
 // An ErrorNoUnwrap() definitions look like this:
 //
-//	func (hasWrapped) Error() string { return hasWrapped.message }
+//	func (hasWrapped) ErrorNoUnwrap() string { return hasWrapped.message }
 //
 // This only needs to be defined if an error has an Unwrap method
 type ErrorNotUnwrapped interface {


### PR DESCRIPTION
[new interfaces SlogMessager and SlogAttributer](https://github.com/gregwebs/errors/commit/9f8e0684dce4e15bb322cb03a276d9d780930737)

These are more convenient for custom error types.
The existing Wraps and Slog is for adding attributes on the fly.