### PR TITLE
add errors.AsType

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -338,6 +338,16 @@ func As(err error, target any) bool {
 	return stderrors.As(err, target)
 }
 
+// AsType is equivalient to As and returns the same boolean.
+// Instead of instantiating a struct and passing it by pointer,
+// the type of the error is given as the generic argument
+// It is instantiated and returned.
+func AsType[Err error](err error) (Err, bool) {
+	var target Err
+	return target, stderrors.As(err, &target)
+}
+
+// HandleWriteError handles errors when writing to fmt.State
 var HandleWriteError = func(err error) {
 	log.Println(err)
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -366,3 +366,35 @@ func TestWalkDeep(t *testing.T) {
 		t.Errorf("found not exists")
 	}
 }
+
+type FindMe struct {
+	a int
+}
+
+func (fm FindMe) Error() string {
+	return "you found me!"
+}
+
+func TestAsType(t *testing.T) {
+	var err error
+	var errAs FindMe
+	var found bool
+	var errorValue = 1
+	err = FindMe{a: errorValue}
+	errAs, found = AsType[FindMe](err)
+	if !found || errAs.a != errorValue {
+		t.Errorf("dif not find error 0 levels deep")
+	}
+
+	err = Wrap(err, "wrapped up")
+	errAs, found = AsType[FindMe](err)
+	if !found || errAs.a != errorValue {
+		t.Errorf("did not find error 1 levels deep")
+	}
+
+	err = nilError{}
+	errAs, found = AsType[FindMe](err)
+	if found {
+		t.Errorf("should not have found a different error type")
+	}
+}


### PR DESCRIPTION
This uses a generic type argument.

The original API takes 2 lines
and panics if you forget to pass the error as pointer.

This new API is a 1 liner that doesn't panic.