### PR TITLE
export error field for easy construction

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -395,15 +395,19 @@ type ErrorWrapper interface {
 // If fulfills the WrapError interface.
 // This allows for wrapping an inner error without changing the outer type.
 type ErrorWrap struct {
-	error
+	Err error
+}
+
+func (ew *ErrorWrap) Error() string {
+	return ew.Err.Error()
 }
 
 func (ew *ErrorWrap) Unwrap() error {
-	return Unwrap(ew.error)
+	return Unwrap(ew.Err)
 }
 
 func (ew *ErrorWrap) WrapError(wrap func(error) error) {
-	ew.error = wrap(ew.error)
+	ew.Err = wrap(ew.Err)
 }
 
 var _ ErrorWrapper = (*ErrorWrap)(nil) // assert implements interface

--- a/errors_test.go
+++ b/errors_test.go
@@ -424,7 +424,7 @@ type WrapInPlace struct {
 }
 
 func TestErrorWrapper(t *testing.T) {
-	err := WrapInPlace{&ErrorWrap{error: New("underlying")}}
+	err := WrapInPlace{&ErrorWrap{Err: New("underlying")}}
 	if err.Error() != "underlying" {
 		t.Errorf("Error()")
 	}


### PR DESCRIPTION
It is possible to hide this field and instead
provide a constructor function.
However this field is already modifiable
via wrapping.
It's simpler to construct it directly.