### PR TITLE
ErrorWrap interface and re-organize internals

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -134,7 +134,7 @@ func TestWrapf(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := Wrapf(tt.err, tt.message).Error()
+		got := Wrap(tt.err, tt.message).Error()
 		if got != tt.want {
 			t.Errorf("Wrapf(%v, %q): got: %v, want %v", tt.err, tt.message, got, tt.want)
 		}
@@ -411,8 +411,9 @@ func TestFormatWrapped(t *testing.T) {
 		t.Errorf("Unexpected wrapping format: %+v", wrapped)
 	}
 	unwrapped := Unwrap(wrapped)
-	if fmt.Sprintf("%v", unwrapped) != "underlying" {
-		t.Errorf("Unexpected unwrapping format: %v", wrapped)
+	got := fmt.Sprintf("%v", unwrapped)
+	if got != "underlying" {
+		t.Errorf("Unexpected unwrapping format, got: %s, wrapped: %v", got, wrapped)
 	}
 	if !strings.HasPrefix(fmt.Sprintf("%+v", unwrapped), "underlying") {
 		t.Errorf("Unexpected unwrapping format: %+v", wrapped)

--- a/stack.go
+++ b/stack.go
@@ -13,6 +13,22 @@ type StackTracer interface {
 	StackTrace() StackTrace
 }
 
+// GetStackTracer will return the first StackTracer in the causer chain.
+// This function is used by AddStack to avoid creating redundant stack traces.
+//
+// You can also use the StackTracer interface on the returned error to get the stack trace.
+func GetStackTracer(origErr error) StackTracer {
+	var stacked StackTracer
+	WalkDeep(origErr, func(err error) bool {
+		if stackTracer, ok := err.(StackTracer); ok {
+			stacked = stackTracer
+			return true
+		}
+		return false
+	})
+	return stacked
+}
+
 // Frame represents a program counter inside a stack frame.
 type Frame uintptr
 

--- a/stack_test.go
+++ b/stack_test.go
@@ -188,6 +188,9 @@ func TestStackTrace(t *testing.T) {
 	}}
 	for i, tt := range tests {
 		ste := GetStackTracer(tt.err)
+		if ste == nil {
+			t.Fatalf("expected a stack trace from test %d error: %v", i+1, tt.err)
+		}
 		st := ste.StackTrace()
 		for j, want := range tt.want {
 			testFormatRegexp(t, i, st[j], "%+v", want)
@@ -247,19 +250,19 @@ func TestStackTraceFormat(t *testing.T) {
 	}, {
 		stackTrace()[:2],
 		"%v",
-		`[stack_test.go:201 stack_test.go:248]`,
+		`[stack_test.go:204 stack_test.go:251]`,
 	}, {
 		stackTrace()[:2],
 		"%+v",
 		"\n" +
 			"github.com/gregwebs/errors.stackTrace\n" +
-			"\tgithub.com/gregwebs/errors/stack_test.go:201\n" +
+			"\tgithub.com/gregwebs/errors/stack_test.go:204\n" +
 			"github.com/gregwebs/errors.TestStackTraceFormat\n" +
-			"\tgithub.com/gregwebs/errors/stack_test.go:252",
+			"\tgithub.com/gregwebs/errors/stack_test.go:255",
 	}, {
 		stackTrace()[:2],
 		"%#v",
-		`[]errors.Frame{stack_test.go:201, stack_test.go:260}`,
+		`[]errors.Frame{stack_test.go:204, stack_test.go:263}`,
 	}}
 
 	for i, tt := range tests {

--- a/structured.go
+++ b/structured.go
@@ -177,7 +177,7 @@ func SlogRecord(inputErr error) *slog.Record {
 						msgUnrecognized = ""
 					}
 				}
-			} else if noUnwrap, ok := err.(ErrorNotUnwrapped); ok {
+			} else if noUnwrap, ok := err.(ErrorUnwrap); ok {
 				if msg := noUnwrap.ErrorNoUnwrap(); msg != "" {
 					if msgUnrecognized == "" || strings.HasPrefix(msgUnrecognized, msg) {
 						msgs = append(msgs, msg)


### PR DESCRIPTION
The ErrorWrap interface is useful for formatting.
Use this to reuse formatting code.
And to forward formatting for ErrorWrap

non-fundamental errors also reuse a common formatError helper.