### PR TITLE
remove the Find function

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -314,20 +314,6 @@ func Unwrap(err error) error {
 	return u.Unwrap()
 }
 
-// Find an error in the chain that matches a test function.
-// returns nil if no error is found.
-func Find(origErr error, test func(error) bool) error {
-	var foundErr error
-	WalkDeep(origErr, func(err error) bool {
-		if test(err) {
-			foundErr = err
-			return true
-		}
-		return false
-	})
-	return foundErr
-}
-
 // A re-export of the standard library errors.Is
 func Is(err, target error) bool {
 	return stderrors.Is(err, target)

--- a/errors_test.go
+++ b/errors_test.go
@@ -280,39 +280,6 @@ func TestErrorEquality(t *testing.T) {
 	}
 }
 
-func TestFind(t *testing.T) {
-	eNew := errors.New("error")
-	wrapped := Wrap(nilError{}, "nil")
-	tests := []struct {
-		err    error
-		finder func(error) bool
-		found  error
-	}{
-		{io.EOF, func(_ error) bool { return true }, io.EOF},
-		{io.EOF, func(_ error) bool { return false }, nil},
-		{io.EOF, func(err error) bool { return err == io.EOF }, io.EOF},
-		{io.EOF, func(err error) bool { return err != io.EOF }, nil},
-
-		{eNew, func(err error) bool { return true }, eNew},
-		{eNew, func(err error) bool { return false }, nil},
-
-		{nilError{}, func(err error) bool { return true }, nilError{}},
-		{nilError{}, func(err error) bool { return false }, nil},
-		{nilError{}, func(err error) bool { _, ok := err.(nilError); return ok }, nilError{}},
-
-		{wrapped, func(err error) bool { return true }, wrapped},
-		{wrapped, func(err error) bool { return false }, nil},
-		{wrapped, func(err error) bool { _, ok := err.(nilError); return ok }, nilError{}},
-	}
-
-	for _, tt := range tests {
-		got := Find(tt.err, tt.finder)
-		if got != tt.found {
-			t.Errorf("WithMessage(%v): got: %q, want %q", tt.err, got, tt.found)
-		}
-	}
-}
-
 type errWalkTest struct {
 	cause error
 	sub   []error


### PR DESCRIPTION
Most of the time users will use Is, As, or AsType
The Find function is easy to write if it is needed.